### PR TITLE
fix fused provider spec

### DIFF
--- a/test/spec/helpers/fused_spec.rb
+++ b/test/spec/helpers/fused_spec.rb
@@ -74,6 +74,8 @@ describe Poise::Helpers::Fused do
   end # /context with setting a default action
 
   context 'with an explicit provider' do
+    resource(:poise_test2) do
+    end
     provider(:poise_test2) do
       include Poise
       def action_run


### PR DESCRIPTION
to reference the provider there needs to be a wrapping resource
that resolves to it
