### PR TITLE
enforce a clean $PATH variable in poise_shell_out

### DIFF
--- a/lib/poise/utils/shell_out.rb
+++ b/lib/poise/utils/shell_out.rb
@@ -74,6 +74,10 @@ module Poise
         if respond_to?(:node) && node.platform_family?('windows')
           command_args = [Poise::Utils::Win32.reparse_command(*command_args)]
         end
+
+        # avoid linking against something in /opt/chef/embedded/
+        # see also: https://github.com/chef/chef/pull/6014
+        options[:environment]['PATH'] ||= ENV['PATH']
         # Call Chef's shell_out wrapper.
         shell_out(*command_args, **options)
       end


### PR DESCRIPTION
chef mangles the $PATH if no specific path is defined in `shell_out`.
This breaks the build of some packages with C extions in poise-python.

To keep the $PATH clean, we set the environment['PATH'] to ENV['PATH']

See also https://github.com/chef/chef/pull/6014

poise-python Bug: https://github.com/poise/poise-python/issues/47